### PR TITLE
feat: 환산 단위 관리 기능 구현

### DIFF
--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/controller/UnitController.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/controller/UnitController.java
@@ -1,0 +1,207 @@
+package com.unit_wiseb.value_calculator.domain.unit.controller;
+
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitIconResponse;
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitRequest;
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitResponse;
+import com.unit_wiseb.value_calculator.domain.unit.service.UnitService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 환산 단위 API 컨트롤러
+ * 단위 조회, 생성, 수정, 삭제
+ */
+@Tag(name = "환산 단위 API", description = "환산 단위 관련 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/units")
+@RequiredArgsConstructor
+public class UnitController {
+
+    private final UnitService unitService;
+
+    /**
+     * 기본 단위 목록 조회
+     * GET /api/units/default
+     */
+    @Operation(
+            summary = "기본 단위 목록 조회",
+            description = "앱에서 제공하는 기본 환산 단위 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/default")
+    public ResponseEntity<List<UnitResponse>> getDefaultUnits() {
+        log.info("기본 단위 목록 조회 요청");
+
+        List<UnitResponse> units = unitService.getDefaultUnits();
+
+        return ResponseEntity.ok(units);
+    }
+
+    /**
+     * 내 커스텀 단위 목록 조회
+     * GET /api/units/my
+     */
+    @Operation(
+            summary = "내 커스텀 단위 목록 조회",
+            description = "사용자가 생성한 커스텀 환산 단위 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/my")
+    public ResponseEntity<List<UnitResponse>> getMyCustomUnits(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestParam Long userId
+    ) {
+        log.info("커스텀 단위 목록 조회 요청: userId={}", userId);
+
+        List<UnitResponse> units = unitService.getMyCustomUnits(userId);
+        return ResponseEntity.ok(units);
+    }
+
+    /**
+     * 모든 단위 조회 (기본 + 커스텀)
+     * GET /api/units/all
+     */
+    @Operation(
+            summary = "모든 단위 조회",
+            description = "기본 단위와 사용자의 커스텀 단위를 모두 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/all")
+    public ResponseEntity<List<UnitResponse>> getAllUnitsForUser(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestParam Long userId
+    ) {
+        log.info("모든 단위 조회 요청: userId={}", userId);
+
+        List<UnitResponse> units = unitService.getAllUnitsForUser(userId);
+
+
+        return ResponseEntity.ok(units);
+    }
+
+    /**
+     * 커스텀 단위 생성
+     * POST /api/units
+     */
+    @Operation(
+            summary = "커스텀 단위 생성",
+            description = "사용자가 새로운 커스텀 환산 단위를 생성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    @PostMapping
+    public ResponseEntity<UnitResponse> createCustomUnit(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestParam Long userId,
+            @Parameter(description = "단위 생성 요청", required = true)
+            @Valid @RequestBody UnitRequest request
+    ) {
+        log.info("커스텀 단위 생성 요청: userId={}, unitName={}", userId, request.getUnitName());
+
+        UnitResponse unit = unitService.createCustomUnit(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(unit);
+    }
+
+    /**
+     * 커스텀 단위 수정 (기본 단위는 수정 불가)
+     * PUT /api/units/{unitId}
+     */
+    @Operation(
+            summary = "커스텀 단위 수정",
+            description = "사용자가 생성한 커스텀 단위를 수정합니다. 기본 단위는 수정할 수 없습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (기본 단위 수정 시도, 권한 없음)"),
+            @ApiResponse(responseCode = "404", description = "단위를 찾을 수 없음")
+    })
+    @PutMapping("/{unitId}")
+    public ResponseEntity<?> updateCustomUnit(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestParam Long userId,
+            @Parameter(description = "단위 ID", required = true)
+            @PathVariable Long unitId,
+            @Parameter(description = "단위 수정 요청", required = true)
+            @Valid @RequestBody UnitRequest request
+    ) {
+        log.info("커스텀 단위 수정 요청: userId={}, unitId={}", userId, unitId);
+
+        try {
+            UnitResponse unit = unitService.updateCustomUnit(userId, unitId, request);
+            return ResponseEntity.ok(unit);
+        } catch (IllegalArgumentException e) {
+            log.error("단위 수정 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    /**
+     * 커스텀 단위 삭제 (기본 단위는 삭제 불가)
+     * DELETE /api/units/{unitId}
+     */
+    @Operation(
+            summary = "커스텀 단위 삭제",
+            description = "사용자가 생성한 커스텀 단위를 삭제합니다. 기본 단위는 삭제할 수 없습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (기본 단위 삭제 시도, 권한 없음)"),
+            @ApiResponse(responseCode = "404", description = "단위를 찾을 수 없음")
+    })
+    @DeleteMapping("/{unitId}")
+    public ResponseEntity<String> deleteCustomUnit(
+            @Parameter(description = "사용자 ID", required = true)
+            @RequestParam Long userId,
+            @Parameter(description = "단위 ID", required = true)
+            @PathVariable Long unitId
+    ) {
+        log.info("커스텀 단위 삭제 요청: userId={}, unitId={}", userId, unitId);
+
+        try {
+            unitService.deleteCustomUnit(userId, unitId);
+            return ResponseEntity.ok("커스텀 단위 삭제 성공");
+        } catch (IllegalArgumentException e) {
+            log.error("단위 삭제 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    /**
+     * 아이콘 목록 조회
+     * GET /api/units/icons
+     */
+    @Operation(
+            summary = "아이콘 목록 조회",
+            description = "커스텀 단위 생성 시 선택 가능한 아이콘 목록을 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @GetMapping("/icons")
+    public ResponseEntity<List<UnitIconResponse>> getAllIcons() {
+        log.info("아이콘 목록 조회 요청");
+
+        List<UnitIconResponse> icons = unitService.getAllIcons();
+
+        return ResponseEntity.ok(icons);
+    }
+}
+
+
+
+
+
+

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitIconResponse.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitIconResponse.java
@@ -1,0 +1,24 @@
+package com.unit_wiseb.value_calculator.domain.unit.dto;
+
+import com.unit_wiseb.value_calculator.domain.unit.entity.UnitIcon;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UnitIconResponse {
+
+    private Long iconId;
+    private String iconEmoji;
+    private String iconName;
+
+    public static UnitIconResponse from(UnitIcon icon) {
+        return UnitIconResponse.builder()
+                .iconId(icon.getId())
+                .iconEmoji(icon.getIconEmoji())
+                .iconName(icon.getIconName())
+                .build();
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitRequest.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitRequest.java
@@ -1,0 +1,29 @@
+package com.unit_wiseb.value_calculator.domain.unit.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 커스텀 단위 생성 요청 DTO
+ * 각 항목들 전부 필수 요건임.
+ */
+@Getter
+@NoArgsConstructor
+public class UnitRequest {
+
+    @NotNull(message = "아이콘 ID는 필수입니다.")
+    private Long iconId;
+
+    @NotBlank(message = "단위명은 필수입니다.")
+    private String unitName;
+
+    @NotNull(message = "단위 가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0원 이상이어야 합니다.")
+    private Integer unitPrice;
+
+    @NotBlank(message = "수량 단위는 필수입니다.")
+    private String unitCounter;
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitResponse.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/dto/UnitResponse.java
@@ -1,0 +1,41 @@
+package com.unit_wiseb.value_calculator.domain.unit.dto;
+
+import com.unit_wiseb.value_calculator.domain.unit.entity.Unit;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 단위 정보를 클라이언트에게 반환
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class UnitResponse {
+
+    private Long unitId;
+
+    private String unitName;
+
+    private Integer unitPrice;
+
+    private String unitCounter;
+
+    private String iconEmoji;
+
+    private String iconName;
+
+    private Boolean isDefault;
+
+    public static UnitResponse from(Unit unit) {
+        return UnitResponse.builder()
+                .unitId(unit.getId())
+                .unitName(unit.getUnitName())
+                .unitPrice(unit.getUnitPrice())
+                .unitCounter(unit.getUnitCounter())
+                .iconEmoji(unit.getIcon() != null ? unit.getIcon().getIconEmoji() : null)
+                .iconName(unit.getIcon() != null ? unit.getIcon().getIconName() : null)
+                .isDefault(unit.getIsDefault())
+                .build();
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/entity/Unit.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/entity/Unit.java
@@ -1,0 +1,68 @@
+package com.unit_wiseb.value_calculator.domain.unit.entity;
+
+import com.unit_wiseb.value_calculator.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "units")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Unit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "unit_id")
+    private Long id;
+
+    /**
+     * 사용자 ID
+     * NULL: 기본 단위
+     * NOT NULL: 특정 사용자의 커스텀 단위
+     */
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "icon_id", nullable = false)
+    private Long iconId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "icon_id", insertable = false, updatable = false)
+    private UnitIcon icon;
+
+    @Column(name = "unit_name", nullable = false, length = 50)
+    private String unitName;
+
+    @Column(name = "unit_price", nullable = false)
+    private Integer unitPrice;
+
+    /**
+     * 수량 단위 (잔, 번, 개, 회? 같은)
+     */
+    @Column(name = "unit_counter", nullable = false, length = 10)
+    private String unitCounter;
+
+    /**
+     * 기본 단위 여부
+     * TRUE: 앱에서 제공하는 기본 단위
+     * FALSE: 사용자가 만든 커스텀 단위
+     */
+    @Column(name = "is_default", nullable = false)
+    @Builder.Default
+    private Boolean isDefault = false;
+
+    /**
+     * 커스텀 단위 정보 업데이트
+     */
+    public void updateCustomUnit(String unitName, Integer unitPrice, String unitCounter, Long iconId) {
+        if (this.isDefault) {
+            throw new IllegalStateException("기본 단위는 수정 불가");
+        }
+        this.unitName = unitName;
+        this.unitPrice = unitPrice;
+        this.unitCounter = unitCounter;
+        this.iconId = iconId;
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/entity/UnitIcon.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/entity/UnitIcon.java
@@ -1,0 +1,25 @@
+package com.unit_wiseb.value_calculator.domain.unit.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Table(name = "unit_icons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UnitIcon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "icon_id")
+    private Long id;
+
+    @Column(name = "icon_emoji", nullable = false, length = 10)
+    private String iconEmoji;
+
+    @Column(name = "icon_name", nullable = false, length = 50)
+    private String iconName;
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/repository/UnitIconRepository.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/repository/UnitIconRepository.java
@@ -1,0 +1,13 @@
+package com.unit_wiseb.value_calculator.domain.unit.repository;
+
+import com.unit_wiseb.value_calculator.domain.unit.entity.UnitIcon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UnitIconRepository extends JpaRepository<UnitIcon, Long> {
+
+    List<UnitIcon> findAll();
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/repository/UnitRepository.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/repository/UnitRepository.java
@@ -1,0 +1,28 @@
+package com.unit_wiseb.value_calculator.domain.unit.repository;
+
+import com.unit_wiseb.value_calculator.domain.unit.entity.Unit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UnitRepository extends JpaRepository<Unit, Long> {
+
+    /**
+     * 기본 단위 목록 조회
+     * user_id가 NULL && is_default가 TRUE
+     */
+    List<Unit> findByUserIdIsNullAndIsDefaultTrue();
+
+    /**
+     * 특정 사용자의 커스텀 단위 목록 조회
+     */
+    List<Unit> findByUserId(Long userId);
+
+    /**
+     * 특정 사용자의 모든 단위 조회 (기본 + 커스텀)
+     * 기본 단위 + 해당 사용자의 커스텀 단위
+     */
+    List<Unit> findByUserIdIsNullAndIsDefaultTrueOrUserId(Long userId);
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/service/UnitService.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/service/UnitService.java
@@ -1,0 +1,195 @@
+package com.unit_wiseb.value_calculator.domain.unit.service;
+
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitIconResponse;
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitRequest;
+import com.unit_wiseb.value_calculator.domain.unit.dto.UnitResponse;
+import com.unit_wiseb.value_calculator.domain.unit.entity.Unit;
+import com.unit_wiseb.value_calculator.domain.unit.entity.UnitIcon;
+import com.unit_wiseb.value_calculator.domain.unit.repository.UnitIconRepository;
+import com.unit_wiseb.value_calculator.domain.unit.repository.UnitRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UnitService {
+
+    private final UnitRepository unitRepository;
+    private final UnitIconRepository unitIconRepository;
+
+    /**
+     * 기본 단위 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<UnitResponse> getDefaultUnits() {
+        log.info("기본 단위 목록 조회");
+
+        List<Unit> units = unitRepository.findByUserIdIsNullAndIsDefaultTrue();
+
+        return units.stream()
+                .map(UnitResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 사용자의 커스텀 단위 목록 조회
+     * 특정 사용자가 생성한 커스텀 단위들
+     */
+    @Transactional(readOnly = true)
+    public List<UnitResponse> getMyCustomUnits(Long userId) {
+        log.info("사용자 커스텀 단위 목록 조회: userId={}", userId);
+
+        List<Unit> units = unitRepository.findByUserId(userId);
+
+        return units.stream()
+                .map(UnitResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 사용자의 모든 단위 조회 (기본 + 커스텀)
+     * 기본 단위와 사용자가 만든 커스텀 단위를 모두 포함
+     */
+    @Transactional(readOnly = true)
+    public List<UnitResponse> getAllUnitsForUser(Long userId) {
+        log.info("사용자의 모든 단위 조회: userId={}", userId);
+
+        List<Unit> units = unitRepository.findByUserIdIsNullAndIsDefaultTrueOrUserId(userId);
+
+        return units.stream()
+                .map(UnitResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 커스텀 단위 생성
+     * 사용자가 새로운 환산 단위를 생성
+     */
+    @Transactional
+    public UnitResponse createCustomUnit(Long userId, UnitRequest request) {
+        log.info("커스텀 단위 생성: userId={}, unitName={}", userId, request.getUnitName());
+
+        // 아이콘 존재 여부 확인
+        UnitIcon icon = unitIconRepository.findById(request.getIconId())
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 아이콘: iconId={}", request.getIconId());
+                    return new IllegalArgumentException("존재하지 않는 아이콘입니다.");
+                });
+
+        // 커스텀 단위 생성
+        Unit unit = Unit.builder()
+                .userId(userId)
+                .iconId(request.getIconId())
+                .unitName(request.getUnitName())
+                .unitPrice(request.getUnitPrice())
+                .unitCounter(request.getUnitCounter())
+                .isDefault(false)  // 커스텀 단위는 기본 단위가 아님
+                .build();
+
+        Unit savedUnit = unitRepository.save(unit);
+
+        log.info("커스텀 단위 생성 완료: unitId={}", savedUnit.getId());
+
+        return UnitResponse.from(savedUnit);
+    }
+
+    /**
+     * 커스텀 단위 수정
+     * 사용자가 생성한 커스텀 단위만 수정 가능 (기본 단위는 수정 불가)
+     */
+    @Transactional
+    public UnitResponse updateCustomUnit(Long userId, Long unitId, UnitRequest request) {
+        log.info("커스텀 단위 수정: userId={}, unitId={}", userId, unitId);
+
+        // 단위 조회
+        Unit unit = unitRepository.findById(unitId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 단위: unitId={}", unitId);
+                    return new IllegalArgumentException("존재하지 않는 단위입니다.");
+                });
+
+        // 권한 확인 >>> 본인의 커스텀 단위만 수정 가능함
+        if (unit.getIsDefault()) {
+            log.error("기본 단위 수정 시도: unitId={}", unitId);
+            throw new IllegalArgumentException("기본 단위는 수정할 수 없습니다.");
+        }
+
+        if (!unit.getUserId().equals(userId)) {
+            log.error("권한 없는 단위 수정 시도: userId={}, unitId={}", userId, unitId);
+            throw new IllegalArgumentException("본인의 단위만 수정할 수 있습니다.");
+        }
+
+        // 아이콘 존재 여부 확인
+        unitIconRepository.findById(request.getIconId())
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 아이콘: iconId={}", request.getIconId());
+                    return new IllegalArgumentException("존재하지 않는 아이콘입니다.");
+                });
+
+        // 단위 정보 업데이트
+        unit.updateCustomUnit(
+                request.getUnitName(),
+                request.getUnitPrice(),
+                request.getUnitCounter(),
+                request.getIconId()
+        );
+
+        log.info("커스텀 단위 수정 완료: unitId={}", unitId);
+
+        return UnitResponse.from(unit);
+    }
+
+    /**
+     * 커스텀 단위 삭제
+     * 사용자가 생성한 커스텀 단위만 삭제 가능 (기본 단위는 삭제 불가)
+     */
+    @Transactional
+    public void deleteCustomUnit(Long userId, Long unitId) {
+        log.info("커스텀 단위 삭제: userId={}, unitId={}", userId, unitId);
+
+        // 단위 조회
+        Unit unit = unitRepository.findById(unitId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 단위: unitId={}", unitId);
+                    return new IllegalArgumentException("존재하지 않는 단위입니다.");
+                });
+
+        // 권한 확인 (본인의 커스텀 단위만 삭제 가능)
+        if (unit.getIsDefault()) {
+            log.error("기본 단위 삭제 시도: unitId={}", unitId);
+            throw new IllegalArgumentException("기본 단위는 삭제할 수 없습니다.");
+        }
+
+        if (!unit.getUserId().equals(userId)) {
+            log.error("권한 없는 단위 삭제 시도: userId={}, unitId={}", userId, unitId);
+            throw new IllegalArgumentException("본인의 단위만 삭제할 수 있습니다.");
+        }
+
+        // 단위 삭제
+        unitRepository.delete(unit);
+
+        log.info("커스텀 단위 삭제 완료: unitId={}", unitId);
+    }
+
+    //TODO 커스텀 단위 생성할 떄 아이콘 선택할때 필요한 아이콘 목록 조회 만들것
+    /**
+     * 모든 아이콘 목록 조회
+     * 커스텀 단위 생성 시 아이콘 선택 때  사용할거임
+     */
+    @Transactional(readOnly = true)
+    public List<UnitIconResponse> getAllIcons() {
+        log.info("아이콘 목록 조회");
+
+        List<UnitIcon> icons = unitIconRepository.findAll();
+
+        return icons.stream()
+                .map(UnitIconResponse::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 주요 기능

### 1. 기본 단위 관리
- 앱에서 제공하는 기본 환산 단위 조회
- 현재 기본 단위(DB에 들어있는): 아메리카노(4,500원), 택시비(4,800원), 햄버거(5,500원), 국밥(10,000원), 하트(무제한-매우작은수)

### 2. 커스텀 단위 CRUD
- 사용자가 직접 환산 단위 생성
- 본인이 만든 커스텀 단위 조회
- 커스텀 단위 수정 (기본 단위는 수정 불가)
- 커스텀 단위 삭제 (기본 단위는 삭제 불가)

### 3. 아이콘 관리
- 단위 생성 시 선택 가능한 아이콘 목록 제공
- 현재 5개 기본 아이콘: ☕ 커피, 🚕 택시, 🍔 햄버거, 🍜 국밥, ❤️ 하트

### 4. 권한 관리
- 사용자는 본인의 커스텀 단위만 수정/삭제 가능
- 기본 단위는 모든 사용자가 읽기만 가능