### PR TITLE
feat: jwt인증 필터 및 사용자 인증 인프라 구현

### DIFF
--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/annotation/CurrentUserId.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/annotation/CurrentUserId.java
@@ -1,0 +1,15 @@
+package com.unit_wiseb.value_calculator.domain.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 현재 인증된 사용자의 ID를 파라미터에 주입하는 어노테이션
+ * JWT 토큰에서 추출한 userId를 자동으로 주입
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/SecurityConfig.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/SecurityConfig.java
@@ -1,40 +1,53 @@
 package com.unit_wiseb.value_calculator.domain.common.config;
 
+import com.unit_wiseb.value_calculator.domain.common.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    /**
-     * @param http HttpSecurity 객체
-     * @return 설정된 SecurityFilterChain
-     * @throws Exception 설정 중 발생할 수 있는 예외
-     */
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 // CSRF 보호 비활성화 (JWT 사용 시 불필요)
                 .csrf(csrf -> csrf.disable())
-                //세션 사용X : JWT기반 인증
+
+                // 세션 사용 안 함 (JWT 기반 인증)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+
+                // 요청 URL별 인증 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers(   //스웨거 관련 경로 허용
+                        .requestMatchers(
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/swagger-ui.html"
                         ).permitAll()
                         .requestMatchers("/", "/health").permitAll()
+                        .requestMatchers("/api/units/default").permitAll()
+                        .requestMatchers("/api/units/icons").permitAll()
                         .anyRequest().authenticated()
+                )
+
+                // JWT 인증 필터
+                // UsernamePasswordAuthenticationFilter 이전에 실행됨
+                .addFilterBefore(
+                        jwtAuthenticationFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/SwaggerConfig.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/SwaggerConfig.java
@@ -29,7 +29,13 @@ public class SwaggerConfig {
                                 .type(SecurityScheme.Type.HTTP)
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
-                                .description("JWT 액세스 토큰을 입력하세요 (Bearer 제외)")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                                .description("JWT 액세스 토큰을 입력하세요.\n\n" +
+                                        "1. /api/auth/kakao/login으로 카카오 로그인\n" +
+                                        "2. /api/auth/kakao/callback에서 받은 accessToken 복사\n" +
+                                        "3. 우측 상단 [Authorize] 버튼 클릭\n" +
+                                        "4. 'Bearer ' 없이 토큰만 입력\n\n")
                         )
                 )
                 // 전역 보안 요구사항

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/WebConfig.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.unit_wiseb.value_calculator.domain.common.config;
+
+import com.unit_wiseb.value_calculator.domain.common.resolver.CurrentUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserIdArgumentResolver currentUserIdArgumentResolver;
+
+    /**
+     * 커스텀 ArgumentResolver 등록
+     * @CurrentUserId 어노테이션 처리를 위한 Resolver 추가
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdArgumentResolver);
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,96 @@
+package com.unit_wiseb.value_calculator.domain.common.filter;
+
+import com.unit_wiseb.value_calculator.domain.user.service.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * HTTP 요청의 Authorization 헤더에서 JWT 토큰을 추출하고 검증
+ * 유효한 토큰인 경우 SecurityContext에 인증 정보 저장
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+
+    /**
+     * 요청마다 실행되는 필터 로직
+     * Authorization 헤더에서 JWT 토큰 추출 및 검증
+     */
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        try {
+            //Authorization 헤더에서 JWT 토큰 추출
+            String token = extractTokenFromRequest(request);
+
+            // 토큰이 있고 유효한 경우
+            if (token != null && jwtService.validateToken(token)) {
+                //토큰에서 사용자 ID 추출해서
+                Long userId = jwtService.getUserIdFromToken(token);
+
+                // spring Security 인증 객체 생성함
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userId,  // principal (사용자 ID)
+                                null,    // credentials (비밀번호 - JWT는 불필요)
+                                new ArrayList<>()  // authorities (권한 목록)
+                        );
+
+                //요청 정보 추가
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+
+                //SecurityContext에 인증 정보 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.debug("JWT 인증 성공: userId={}", userId);
+            }
+
+        } catch (Exception e) {
+            log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
+            // 인증 실패 시 SecurityContext를 비워둠 (인증되지 않은 상태)
+            SecurityContextHolder.clearContext();
+        }
+
+        //다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * HTTP 요청에서 JWT 토큰 추출
+     * Authorization 헤더: "Bearer {token}" 형식
+     */
+    private String extractTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        // "Bearer " 접두사가 있는지 확인
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            // "Bearer " 이후의 토큰 부분만 추출
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/resolver/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/resolver/CurrentUserIdArgumentResolver.java
@@ -1,0 +1,58 @@
+package com.unit_wiseb.value_calculator.domain.common.resolver;
+
+import com.unit_wiseb.value_calculator.domain.common.annotation.CurrentUserId;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @CurrentUserId 어노테이션 처리 Resolver
+ * SecurityContext에서 인증된 사용자 ID를 추출하여 파라미터에 주입
+ */
+@Component
+public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    /**
+     * 이 Resolver가 처리할 수 있는 파라미터인지 확인
+     * -> @CurrentUserId 어노테이션이 있는 Long 타입 파라미터만 처리
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+                && Long.class.equals(parameter.getParameterType());
+    }
+
+    /**
+     * 파라미터 값 추출
+     * SecurityContext에서 인증된 사용자 ID를 가져옴
+     */
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // 인증되지 않았으면,
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new IllegalStateException("인증되지 않은 사용자입니다.");
+        }
+
+        // principal에서 (JwtAuthenticationFilter에서 저장한 값)userId 추출
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof Long) {
+            return principal;
+        }
+
+        throw new IllegalStateException("유효하지 않은 인증 정보입니다.");
+    }
+}


### PR DESCRIPTION
1. JWT 필터 생성(토큰 검증)
    
    <aside>
    
    **1단계: JwtAuthenticationFilter.java - JWT 토큰 검증**
    
    - 왜 필요한가?
        - 클라이언트가 API호출 시 매번 내가 누구인지 증명해야함
        - 하지만 서버는 요청이 올 떄마디 누구인지 모름
        
        ⇒ HTTP 요청의 Authorization 헤더에 JWT 토큰을 달아서 보내면 필터가 자동으로 토큰을 검증하고 해당 사용자가 누구인지 판단
        
    </aside>
    
 2. 커스텀 어노테이션 생성
    
    <aside>
    
    **2단계: @CurrentUserId 어노테이션 - 편의 기능**
    
    - 왜 필요한가?
        
        ⇒ Controller 메서드 파라미터에 붙여서 ‘jwt토큰에서 추출한 userId를 여기 넣으라고 표시하는 마커를 만든것
        
    </aside>
    
    ```java
    // 어노테이션 없이 매번 이렇게 해야 함 (번거로움!)
    @GetMapping("/my")
    public ResponseEntity<?> getMyUnits() {
        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
        Long userId = (Long) auth.getPrincipal();
        // ... userId 사용
    }
    
    // 어노테이션 사용하면 깔끔!
    @GetMapping("/my")
    public ResponseEntity<?> getMyUnits(@CurrentUserId Long userId) {
        // userId가 자동으로 주입됨!
    }
    ```
    
3. ArgumentResolver 생성(어노테이션 처리)
    
    <aside>
    
    **3단계: CurrentUserIdArgumentResolver - 어노테이션 처리기**
    
    : `@CurrentUserId` 어노테이션을 발견하면 실제로 userId 값을 주입해주는 처리기
    
    - 왜 필요한가?
        
        ⇒어노테이션은 단순히 표시를 한거고, 실제 처리는 Resolver가 한다.
        
    </aside>
    
    ```java
    1. Controller 메서드:
       public ResponseEntity<?> getMyUnits(@CurrentUserId Long userId)
    
    2. Spring이 메서드 호출 준비:
       "어? @CurrentUserId 어노테이션이 있네?"
       "이거 처리할 수 있는 Resolver 찾아봐야지"
    
    3. CurrentUserIdArgumentResolver.supportsParameter() 호출:
       "네! 제가 처리할 수 있어요!"
    
    4. CurrentUserIdArgumentResolver.resolveArgument() 호출:
       SecurityContext → Authentication → Principal → userId 추출
       → userId = 1 반환
    
    5. Spring이 Controller 메서드 호출:
       getMyUnits(1)  // userId = 1 자동 주입!
    ```

4. WebConfig 설정(ArgumentResolver 등록)
    
    <aside>
    
    **4단계: WebConfig - ArgumentResolver 등록**
    
    : SpringMVC에 내가 만든 Resolver를 사용할거라고 알려주는 설정
    
    - 왜 필요한가?
        
        ⇒ resolver를 만들고, 스프링에 명시적으로 등록을 해야만 동작한다. 
        
    </aside>
    
5. SecurityConfig 수정 (필터 적용)
    
    <aside>
    
    **5단계: SecurityConfig - 필터 적용
    :** Spring Security에 JWT 필터를 등록하고, 어떤 URL은 인증 필요/불필요한지 설정
    
    - 왜 필요한가?
        
        ⇒ 필터를 만들었지만 Spring Security에 등록하지 않으면 실행되지 않음
        
    </aside>
    
    ```java
    HTTP 요청
       ↓
    1. JwtAuthenticationFilter
       - Authorization 헤더 확인
       - JWT 토큰 검증
       - SecurityContext에 인증 정보 저장
       ↓
    2. UsernamePasswordAuthenticationFilter (Spring Security 기본)
       - 나는 사용 안 함 (JWT 쓰니까)
       ↓
    3. FilterSecurityInterceptor
       - "이 URL 접근 권한 있어?" 확인
       - SecurityContext에 인증 정보 있으면 통과
       ↓
    4. Controller 실행
    
    코드:
    /api/units/default: permitAll() - 누구나
    /api/units/my: authenticated() - 토큰 필요
    ```