### PR TITLE
feat: JWT 인증 필터 및 사용자 인증 시스템 구현

### DIFF
--- a/src/main/java/com/unit_wiseb/value_calculator/domain/unit/controller/UnitController.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/unit/controller/UnitController.java
@@ -1,5 +1,6 @@
 package com.unit_wiseb.value_calculator.domain.unit.controller;
 
+import com.unit_wiseb.value_calculator.domain.common.annotation.CurrentUserId;
 import com.unit_wiseb.value_calculator.domain.unit.dto.UnitIconResponse;
 import com.unit_wiseb.value_calculator.domain.unit.dto.UnitRequest;
 import com.unit_wiseb.value_calculator.domain.unit.dto.UnitResponse;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -55,13 +57,13 @@ public class UnitController {
      */
     @Operation(
             summary = "내 커스텀 단위 목록 조회",
-            description = "사용자가 생성한 커스텀 환산 단위 목록을 조회합니다."
+            description = "사용자가 생성한 커스텀 환산 단위 목록을 조회합니다.",
+            security = @SecurityRequirement(name = "bearer-jwt")
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/my")
     public ResponseEntity<List<UnitResponse>> getMyCustomUnits(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId
+            @Parameter(hidden = true) @CurrentUserId Long userId
     ) {
         log.info("커스텀 단위 목록 조회 요청: userId={}", userId);
 
@@ -75,13 +77,13 @@ public class UnitController {
      */
     @Operation(
             summary = "모든 단위 조회",
-            description = "기본 단위와 사용자의 커스텀 단위를 모두 조회합니다."
+            description = "기본 단위와 사용자의 커스텀 단위를 모두 조회합니다.",
+            security = @SecurityRequirement(name = "bearer-jwt")
     )
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/all")
     public ResponseEntity<List<UnitResponse>> getAllUnitsForUser(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId
+            @Parameter(hidden = true) @CurrentUserId Long userId
     ) {
         log.info("모든 단위 조회 요청: userId={}", userId);
 
@@ -97,7 +99,8 @@ public class UnitController {
      */
     @Operation(
             summary = "커스텀 단위 생성",
-            description = "사용자가 새로운 커스텀 환산 단위를 생성합니다."
+            description = "사용자가 새로운 커스텀 환산 단위를 생성합니다.",
+            security = @SecurityRequirement(name = "bearer-jwt")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "생성 성공"),
@@ -105,8 +108,7 @@ public class UnitController {
     })
     @PostMapping
     public ResponseEntity<UnitResponse> createCustomUnit(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId,
+            @Parameter(hidden = true) @CurrentUserId Long userId,
             @Parameter(description = "단위 생성 요청", required = true)
             @Valid @RequestBody UnitRequest request
     ) {
@@ -123,7 +125,8 @@ public class UnitController {
      */
     @Operation(
             summary = "커스텀 단위 수정",
-            description = "사용자가 생성한 커스텀 단위를 수정합니다. 기본 단위는 수정할 수 없습니다."
+            description = "사용자가 생성한 커스텀 단위를 수정합니다. 기본 단위는 수정할 수 없습니다.",
+            security = @SecurityRequirement(name = "bearer-jwt")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
@@ -132,8 +135,7 @@ public class UnitController {
     })
     @PutMapping("/{unitId}")
     public ResponseEntity<?> updateCustomUnit(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId,
+            @Parameter(hidden = true) @CurrentUserId Long userId,
             @Parameter(description = "단위 ID", required = true)
             @PathVariable Long unitId,
             @Parameter(description = "단위 수정 요청", required = true)
@@ -156,7 +158,8 @@ public class UnitController {
      */
     @Operation(
             summary = "커스텀 단위 삭제",
-            description = "사용자가 생성한 커스텀 단위를 삭제합니다. 기본 단위는 삭제할 수 없습니다."
+            description = "사용자가 생성한 커스텀 단위를 삭제합니다. 기본 단위는 삭제할 수 없습니다.",
+            security = @SecurityRequirement(name = "bearer-jwt")
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
@@ -165,8 +168,7 @@ public class UnitController {
     })
     @DeleteMapping("/{unitId}")
     public ResponseEntity<String> deleteCustomUnit(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId,
+            @Parameter(hidden = true) @CurrentUserId Long userId,
             @Parameter(description = "단위 ID", required = true)
             @PathVariable Long unitId
     ) {

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/user/controller/AuthController.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/user/controller/AuthController.java
@@ -88,23 +88,24 @@ public class AuthController {
      * POST /api/auth/logout
      * 리프레시 토큰을 DB에서 삭제
      * 클라이언트는 로컬 스토리지의 토큰도 함께 삭제해야 함!!!!
+     * 가치계산기는 다음 사이트에서 모듈로 들어가는 부분이므로 당장 로그아웃 기능이 필요하지 않아. 주석처리하였음
      */
-    @Operation(
-            summary = "로그아웃",
-            description = "리프레시 토큰을 삭제하여 로그아웃 처리합니다."
-    )
-    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
-    @PostMapping("/logout")
-    public ResponseEntity<String> logout(
-            @Parameter(description = "사용자 ID", required = true)
-            @RequestParam Long userId
-    ) {
-        log.info("로그아웃 요청: userId={}", userId);
-
-        kakaoAuthService.logout(userId);
-
-        return ResponseEntity.ok("로그아웃 성공");
-    }
+//    @Operation(
+//            summary = "로그아웃",
+//            description = "리프레시 토큰을 삭제하여 로그아웃 처리합니다."
+//    )
+//    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+//    @PostMapping("/logout")
+//    public ResponseEntity<String> logout(
+//            @Parameter(description = "사용자 ID", required = true)
+//            @RequestParam Long userId
+//    ) {
+//        log.info("로그아웃 요청: userId={}", userId);
+//
+//        kakaoAuthService.logout(userId);
+//
+//        return ResponseEntity.ok("로그아웃 성공");
+//    }
 
     /**
      * 토큰 갱신


### PR DESCRIPTION
JWT 인증 필터를 구현하고 Unit 도메인에 적용
=>  사용자는 더 이상 쿼리 파라미터로 userId를 전달하지 않고, JWT 토큰으로 자동 인증됨

## 주요 기능

### 1. JWT 인증 인프라
- **JwtAuthenticationFilter**: Authorization 헤더에서 JWT 토큰 추출 및 검증
- **@CurrentUserId**: Controller 파라미터에 userId 자동 주입
- **CurrentUserIdArgumentResolver**: @CurrentUserId 어노테이션 처리
- **SecurityConfig**: JWT 필터 등록 및 URL별 인증 설정

### 2. Controller 리팩토링
- **UnitController**: `@RequestParam Long userId` → `@CurrentUserId Long userId`
- **AuthController**: logout 메서드 제거 (모듈 방식)

### 3. Swagger 인증 UI
- JWT Bearer 인증 스키마 추가
- [Authorize] 버튼으로 토큰 입력
- 인증 필요한 API에 🔒 자물쇠 아이콘 표시

### 4. 보안 강화
- 쿼리 파라미터 방식 → JWT 토큰 방식
- 타인의 userId로 요청 불가
- 토큰 검증 실패 시 401 Unauthorized