### PR TITLE
feat: 위시리스트 도메인 구현

### DIFF
--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/controller/WishlistController.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/controller/WishlistController.java
@@ -1,0 +1,189 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.controller;
+
+import com.unit_wiseb.value_calculator.domain.common.annotation.CurrentUserId;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.request.WishlistCreateRequest;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.request.WishlistUpdateRequest;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.response.WishlistDetailResponse;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.response.WishlistResponse;
+import com.unit_wiseb.value_calculator.domain.wishlist.service.WishlistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/wishlists")
+@RequiredArgsConstructor
+@Tag(name = "Wishlist", description = "위시리스트 API")
+@SecurityRequirement(name = "bearerAuth")
+public class WishlistController {
+
+    private final WishlistService wishlistService;
+
+    /**
+     * 위시리스트 생성
+     * POST /api/wishlists
+     */
+    @PostMapping
+    @Operation(summary = "위시리스트 생성", description = "새로운 위시리스트를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "위시리스트 생성 성공",
+                    content = @Content(schema = @Schema(implementation = WishlistResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    public ResponseEntity<WishlistResponse> createWishlist(
+            @Parameter(hidden = true) @CurrentUserId Long userId,
+            @Valid @RequestBody WishlistCreateRequest request
+    ) {
+        WishlistResponse response = wishlistService.createWishlist(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 진행 중인 위시리스트 조회
+     * GET /api/wishlists/my/in-progress
+     */
+    @GetMapping("/my/in-progress")
+    @Operation(summary = "진행 중인 위시리스트 조회", description = "목표를 달성하지 못한 위시리스트를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = WishlistResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    public ResponseEntity<List<WishlistResponse>> getInProgressWishlists(
+            @Parameter(hidden = true) @CurrentUserId Long userId
+    ) {
+        List<WishlistResponse> response = wishlistService.getInProgressWishlists(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 위시리스트 상세 조회
+     * GET /api/wishlists/{wishlistId}
+     */
+    @GetMapping("/{wishlistId}")
+    @Operation(summary = "위시리스트 상세 조회", description = "특정 위시리스트의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = WishlistDetailResponse.class))
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "위시리스트를 찾을 수 없음")
+    })
+    public ResponseEntity<WishlistDetailResponse> getWishlistDetail(
+            @Parameter(hidden = true) @CurrentUserId Long userId,
+            @Parameter(description = "위시리스트 ID", example = "1") @PathVariable Long wishlistId
+    ) {
+        WishlistDetailResponse response = wishlistService.getWishlistDetail(userId, wishlistId);
+        return ResponseEntity.ok(response);
+    }
+
+
+    /**
+     * 위시리스트 수정
+     * PUT /api/wishlists/{wishlistId}
+     */
+    @PutMapping("/{wishlistId}")
+    @Operation(summary = "위시리스트 수정", description = "위시리스트 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = WishlistResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "위시리스트를 찾을 수 없음")
+    })
+    public ResponseEntity<WishlistResponse> updateWishlist(
+            @Parameter(hidden = true) @CurrentUserId Long userId,
+            @Parameter(description = "위시리스트 ID", example = "1") @PathVariable Long wishlistId,
+            @Valid @RequestBody WishlistUpdateRequest request
+    ) {
+        WishlistResponse response = wishlistService.updateWishlist(userId, wishlistId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 위시리스트 삭제
+     * DELETE /api/wishlists/{wishlistId}
+     */
+    @DeleteMapping("/{wishlistId}")
+    @Operation(summary = "위시리스트 삭제", description = "위시리스트를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "위시리스트를 찾을 수 없음")
+    })
+    public ResponseEntity<Void> deleteWishlist(
+            @Parameter(hidden = true) @CurrentUserId Long userId,
+            @Parameter(description = "위시리스트 ID", example = "1") @PathVariable Long wishlistId
+    ) {
+        wishlistService.deleteWishlist(userId, wishlistId);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    /**
+     * 내 위시리스트 목록 조회 (전체)
+     * GET /api/wishlists/my
+     */
+//    @GetMapping("/my")
+//    @Operation(summary = "내 위시리스트 목록 조회", description = "내 모든 위시리스트를 조회합니다. (최신순)")
+//    @ApiResponses({
+//            @ApiResponse(
+//                    responseCode = "200",
+//                    description = "조회 성공",
+//                    content = @Content(schema = @Schema(implementation = WishlistResponse.class))
+//            ),
+//            @ApiResponse(responseCode = "401", description = "인증 실패")
+//    })
+//    public ResponseEntity<List<WishlistResponse>> getMyWishlists(
+//            @Parameter(hidden = true) @CurrentUserId Long userId
+//    ) {
+//        List<WishlistResponse> response = wishlistService.getMyWishlists(userId);
+//        return ResponseEntity.ok(response);
+//    }
+
+
+    /**
+     * 완료된 위시리스트 조회
+     * GET /api/wishlists/my/completed
+     */
+//    @GetMapping("/my/completed")
+//    @Operation(summary = "완료된 위시리스트 조회", description = "목표를 달성한 위시리스트를 조회합니다.")
+//    @ApiResponses({
+//            @ApiResponse(
+//                    responseCode = "200",
+//                    description = "조회 성공",
+//                    content = @Content(schema = @Schema(implementation = WishlistResponse.class))
+//            ),
+//            @ApiResponse(responseCode = "401", description = "인증 실패")
+//    })
+//    public ResponseEntity<List<WishlistResponse>> getCompletedWishlists(
+//            @Parameter(hidden = true) @CurrentUserId Long userId
+//    ) {
+//        List<WishlistResponse> response = wishlistService.getCompletedWishlists(userId);
+//        return ResponseEntity.ok(response);
+//    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/request/WishlistCreateRequest.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/request/WishlistCreateRequest.java
@@ -1,0 +1,31 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "위시리스트 생성 요청")
+public class WishlistCreateRequest {
+
+    @NotBlank(message = "상품명은 필수입니다.")
+    @Size(max = 200, message = "상품명은 200자 이하여야 합니다.(추후 정할 것)")
+    @Schema(description = "상품명", example = "에어팟 프로 2세대")
+    private String itemName;
+
+    @NotNull(message = "목표 금액은 필수입니다.")
+    @Min(value = 1, message = "목표 금액은 1원 이상이어야 합니다.")
+    @Schema(description = "목표 금액(원)", example = "700000")
+    private Integer targetPrice;
+
+    @Size(max = 500, message = "상품 URL은 500자 이하여야 합니다.")
+    @Schema(description = "상품 URL (선택)", example = "https://www.apple.com/kr/airpods-pro/")
+    private String itemUrl;
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/request/WishlistUpdateRequest.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/request/WishlistUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 모든 필드는 선택사항이며, 제공된 필드만 수정되도록함
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "위시리스트 수정 요청")
+public class WishlistUpdateRequest {
+
+    @Size(max = 200, message = "상품명은 200자 이하여야 합니다.(추후 정할 것)")
+    @Schema(description = "상품명 (선택)", example = "에어팟 프로 3세대")
+    private String itemName;
+
+    @Min(value = 1, message = "목표 금액은 1원 이상이어야 합니다.")
+    @Schema(description = "목표 금액(원) (선택)", example = "700000")
+    private Integer targetPrice;
+
+    @Size(max = 500, message = "상품 URL은 500자 이하여야 합니다.")
+    @Schema(description = "상품 URL (선택)", example = "https://www.apple.com/kr/airpods-pro/")
+    private String itemUrl;
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/response/WishlistDetailResponse.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/response/WishlistDetailResponse.java
@@ -1,0 +1,72 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.dto.response;
+
+import com.unit_wiseb.value_calculator.domain.wishlist.entity.Wishlist;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 나중에 절약 기록(savings) 목록도 포함될 예정임
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "위시리스트 상세 응답")
+public class WishlistDetailResponse {
+
+    @Schema(description = "위시리스트 ID", example = "1")
+    private Long wishlistId;
+
+    @Schema(description = "상품명", example = "에어팟 프로 2세대")
+    private String itemName;
+
+    @Schema(description = "목표 금액(원)", example = "359000")
+    private Integer targetPrice;
+
+    @Schema(description = "현재 절약 금액(원)", example = "150000")
+    private Integer currentAmount;
+
+    @Schema(description = "남은 금액(원)", example = "209000")
+    private Integer remainingAmount;
+
+    @Schema(description = "상품 URL", example = "https://www.apple.com/kr/airpods-pro/")
+    private String itemUrl;
+
+    @Schema(description = "목표 달성 여부", example = "false")
+    private Boolean isCompleted;
+
+    @Schema(description = "목표 달성률(%)", example = "41.78")
+    private Double completionRate;
+
+    @Schema(description = "목표 달성 시각", example = "2025-11-24T10:30:00")
+    private LocalDateTime completedAt;
+
+    @Schema(description = "생성 시각", example = "2025-11-20T14:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각", example = "2025-11-24T09:15:00")
+    private LocalDateTime updatedAt;
+
+    // TODO:절약 기록(savings) 목록 추가
+    // private List<SavingResponse> savings;
+
+
+    public static WishlistDetailResponse from(Wishlist wishlist) {
+        return WishlistDetailResponse.builder()
+                .wishlistId(wishlist.getWishlistId())
+                .itemName(wishlist.getItemName())
+                .targetPrice(wishlist.getTargetPrice())
+                .currentAmount(wishlist.getCurrentAmount())
+                .remainingAmount(Math.max(0, wishlist.getTargetPrice() - wishlist.getCurrentAmount()))
+                .itemUrl(wishlist.getItemUrl())
+                .isCompleted(wishlist.getIsCompleted())
+                .completionRate(wishlist.getCompletionRate())
+                .completedAt(wishlist.getCompletedAt())
+                .createdAt(wishlist.getCreatedAt())
+                .updatedAt(wishlist.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/response/WishlistResponse.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/dto/response/WishlistResponse.java
@@ -1,0 +1,64 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.dto.response;
+
+import com.unit_wiseb.value_calculator.domain.wishlist.entity.Wishlist;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+//목록용
+@Getter
+@AllArgsConstructor
+@Builder
+@Schema(description = "위시리스트 응답")
+public class WishlistResponse {
+
+    @Schema(description = "위시리스트 ID", example = "1")
+    private Long wishlistId;
+
+    @Schema(description = "상품명", example = "에어팟 프로 2세대")
+    private String itemName;
+
+    @Schema(description = "목표 금액(원)", example = "359000")
+    private Integer targetPrice;
+
+    @Schema(description = "현재 절약 금액(원)", example = "150000")
+    private Integer currentAmount;
+
+    @Schema(description = "상품 URL", example = "https://www.apple.com/kr/airpods-pro/")
+    private String itemUrl;
+
+    @Schema(description = "목표 달성 여부", example = "false")
+    private Boolean isCompleted;
+
+    @Schema(description = "목표 달성률(%)", example = "41.78")
+    private Double completionRate;
+
+    @Schema(description = "목표 달성 시각", example = "2025-11-24T10:30:00")
+    private LocalDateTime completedAt;
+
+    @Schema(description = "생성 시각", example = "2025-11-20T14:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시각", example = "2025-11-24T09:15:00")
+    private LocalDateTime updatedAt;
+
+
+
+    public static WishlistResponse from(Wishlist wishlist) {
+        return WishlistResponse.builder()
+                .wishlistId(wishlist.getWishlistId())
+                .itemName(wishlist.getItemName())
+                .targetPrice(wishlist.getTargetPrice())
+                .currentAmount(wishlist.getCurrentAmount())
+                .itemUrl(wishlist.getItemUrl())
+                .isCompleted(wishlist.getIsCompleted())
+                .completionRate(wishlist.getCompletionRate())
+                .completedAt(wishlist.getCompletedAt())
+                .createdAt(wishlist.getCreatedAt())
+                .updatedAt(wishlist.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/entity/Wishlist.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/entity/Wishlist.java
@@ -1,0 +1,120 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "wishlists")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Wishlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wishlist_id")
+    private Long wishlistId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "item_name", nullable = false, length = 200)
+    private String itemName;
+
+    @Column(name = "target_price", nullable = false)
+    private Integer targetPrice;
+
+    @Column(name = "current_amount", nullable = false)
+    @Builder.Default
+    private Integer currentAmount = 0;
+
+    @Column(name = "item_url", length = 500)
+    private String itemUrl;
+
+    @Column(name = "is_completed", nullable = false)
+    @Builder.Default
+    private Boolean isCompleted = false;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 위시리스트 정보 수정
+     * @param itemName 상품명 (null이면 수정 안 함)
+     * @param targetPrice 목표 금액 (null이면 수정 안 함)
+     * @param itemUrl 상품 URL (null이면 수정 안 함)
+     */
+    public void updateWishlist(String itemName, Integer targetPrice, String itemUrl) {
+        if (itemName != null) {
+            this.itemName = itemName;
+        }
+        if (targetPrice != null) {
+            this.targetPrice = targetPrice;
+        }
+        if (itemUrl != null) {
+            this.itemUrl = itemUrl;
+        }
+    }
+
+    /**
+     * 절약 금액 추가 (절약 기록 생성 시 호출)
+     * 목표 금액 달성 시 isCompleted = true로 변경
+     */
+    public void addSavingAmount(Integer amount) {
+        this.currentAmount += amount;
+
+        // 목표 달성 체크
+        if (this.currentAmount >= this.targetPrice && !this.isCompleted) {
+            this.isCompleted = true;
+            this.completedAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * 절약 금액 차감 (절약 기록 삭제 시 호출)
+     * 목표 금액 미달 시 isCompleted = false로 변경
+     */
+    public void subtractSavingAmount(Integer amount) {
+        this.currentAmount -= amount;
+
+        // 목표 미달성으로 변경
+        if (this.currentAmount < this.targetPrice && this.isCompleted) {
+            this.isCompleted = false;
+            this.completedAt = null;
+        }
+    }
+
+    /**
+     * 목표 달성률 계산(0.0 ~ 100.0)
+     */
+    public double getCompletionRate() {
+        if (targetPrice == 0) {
+            return 0.0;
+        }
+        return Math.min((double) currentAmount / targetPrice * 100, 100.0);
+    }
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/repository/WishlistRepository.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/repository/WishlistRepository.java
@@ -1,0 +1,33 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.repository;
+
+import com.unit_wiseb.value_calculator.domain.wishlist.entity.Wishlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WishlistRepository extends JpaRepository<Wishlist, Long> {
+
+    /**
+     * 특정 사용자의 모든 위시리스트 조회 (최신순)
+     */
+    List<Wishlist> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * 특정 사용자의 위시리스트 조회 (위시리스트 ID)
+     */
+    Optional<Wishlist> findByWishlistIdAndUserId(Long wishlistId, Long userId);
+
+    /**
+     * 특정 사용자의 진행 중인 위시리스트 조회
+     */
+    List<Wishlist> findByUserIdAndIsCompletedFalseOrderByCreatedAtDesc(Long userId);
+
+    /**
+     * TODO 쓸지 안쓸지 확인할것. -> 주석처리 여부 결정
+     * 특정 사용자의 완료된 위시리스트 조회
+     */
+    List<Wishlist> findByUserIdAndIsCompletedTrueOrderByCompletedAtDesc(Long userId);
+}

--- a/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/service/WishlistService.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/wishlist/service/WishlistService.java
@@ -1,0 +1,153 @@
+package com.unit_wiseb.value_calculator.domain.wishlist.service;
+
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.request.WishlistCreateRequest;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.request.WishlistUpdateRequest;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.response.WishlistDetailResponse;
+import com.unit_wiseb.value_calculator.domain.wishlist.dto.response.WishlistResponse;
+import com.unit_wiseb.value_calculator.domain.wishlist.entity.Wishlist;
+import com.unit_wiseb.value_calculator.domain.wishlist.repository.WishlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class WishlistService {
+
+    private final WishlistRepository wishlistRepository;
+
+    /**
+     * 위시리스트 생성
+     */
+    @Transactional
+    public WishlistResponse createWishlist(Long userId, WishlistCreateRequest request) {
+        log.info("위시리스트 생성 요청: userId={}, itemName={}", userId, request.getItemName());
+
+        // 위시리스트 엔티티 생성
+        Wishlist wishlist = Wishlist.builder()
+                .userId(userId)
+                .itemName(request.getItemName())
+                .targetPrice(request.getTargetPrice())
+                .itemUrl(request.getItemUrl())
+                .currentAmount(0)
+                .isCompleted(false)
+                .build();
+
+        Wishlist savedWishlist = wishlistRepository.save(wishlist);
+
+        log.info("위시리스트 생성 완료: wishlistId={}", savedWishlist.getWishlistId());
+
+        return WishlistResponse.from(savedWishlist);
+    }
+
+    /**
+     * 진행 중인 위시리스트 조회
+     */
+    public List<WishlistResponse> getInProgressWishlists(Long userId) {
+        log.info("진행 중인 위시리스트 조회: userId={}", userId);
+
+        List<Wishlist> wishlists = wishlistRepository.findByUserIdAndIsCompletedFalseOrderByCreatedAtDesc(userId);
+
+        return wishlists.stream()
+                .map(WishlistResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 위시리스트 상세 조회
+     */
+    public WishlistDetailResponse getWishlistDetail(Long userId, Long wishlistId) {
+        log.info("위시리스트 상세 조회: userId={}, wishlistId={}", userId, wishlistId);
+
+        Wishlist wishlist = wishlistRepository.findByWishlistIdAndUserId(wishlistId, userId)
+                .orElseThrow(() -> {
+                    log.warn("위시리스트를 찾을 수 없음: wishlistId={}, userId={}", wishlistId, userId);
+                    return new IllegalArgumentException("위시리스트를 찾을 수 없습니다.");
+                });
+
+        return WishlistDetailResponse.from(wishlist);
+    }
+
+    /**
+     * 위시리스트 수정
+     */
+    @Transactional
+    public WishlistResponse updateWishlist(Long userId, Long wishlistId, WishlistUpdateRequest request) {
+        log.info("위시리스트 수정 요청: userId={}, wishlistId={}", userId, wishlistId);
+
+        // 위시리스트 조회 및 권한 확인
+        Wishlist wishlist = wishlistRepository.findByWishlistIdAndUserId(wishlistId, userId)
+                .orElseThrow(() -> {
+                    log.warn("위시리스트를 찾을 수 없음: wishlistId={}, userId={}", wishlistId, userId);
+                    return new IllegalArgumentException("위시리스트를 찾을 수 없습니다.");
+                });
+
+        // 위시리스트 수정 (엔티티의 비즈니스 메서드 사용)
+        wishlist.updateWishlist(
+                request.getItemName(),
+                request.getTargetPrice(),
+                request.getItemUrl()
+        );
+
+        log.info("위시리스트 수정 완료: wishlistId={}", wishlistId);
+
+        return WishlistResponse.from(wishlist);
+    }
+
+    /**
+     * 위시리스트 삭제
+     */
+    @Transactional
+    public void deleteWishlist(Long userId, Long wishlistId) {
+        log.info("위시리스트 삭제 요청: userId={}, wishlistId={}", userId, wishlistId);
+
+        // 위시리스트 조회 및 권한 확인
+        Wishlist wishlist = wishlistRepository.findByWishlistIdAndUserId(wishlistId, userId)
+                .orElseThrow(() -> {
+                    log.warn("위시리스트를 찾을 수 없음: wishlistId={}, userId={}", wishlistId, userId);
+                    return new IllegalArgumentException("위시리스트를 찾을 수 없습니다.");
+                });
+
+        wishlistRepository.delete(wishlist);
+
+        log.info("위시리스트 삭제 완료: wishlistId={}", wishlistId);
+    }
+
+
+
+
+
+    //TODO 기능정의 화인할 것
+
+    /**
+     * 내 위시리스트 목록 조회 (전체)
+     */
+    public List<WishlistResponse> getMyWishlists(Long userId) {
+        log.info("위시리스트 목록 조회: userId={}", userId);
+
+        List<Wishlist> wishlists = wishlistRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        return wishlists.stream()
+                .map(WishlistResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 완료된 위시리스트 조회
+     */
+    public List<WishlistResponse> getCompletedWishlists(Long userId) {
+        log.info("완료된 위시리스트 조회: userId={}", userId);
+
+        List<Wishlist> wishlists = wishlistRepository.findByUserIdAndIsCompletedTrueOrderByCompletedAtDesc(userId);
+
+        return wishlists.stream()
+                .map(WishlistResponse::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 1. 위시리스트 CRUD
- **생성**: 상품명, 목표 금액, 상품 URL 등록
- **조회**: 
  - 전체 위시리스트 조회 (최신순)
  - 진행 중인 위시리스트 조회 (미완료)
  - 완료된 위시리스트 조회 (달성순)
- **상세 조회**: 특정 위시리스트 상세 정보
- **수정**: 상품명, 목표 금액, URL 수정
- **삭제**: 위시리스트 삭제

### 2. 목표 달성 시스템
- **자동 달성률 계산**: `(현재금액 / 목표금액) * 100`
- **자동 달성 체크**: 절약 금액이 목표 금액 도달 시 자동 완료
- **달성 시각 기록**: 목표 달성 시 `completed_at` 자동 설정

### 3. JWT 인증 통합
- `@CurrentUserId`로 사용자 자동 인증
- 본인의 위시리스트만 조회/수정/삭제 가능
- Swagger에서 JWT 토큰 인증 필요