### PR TITLE
fix: JWT 필터에 ROLE_USER 권한 추가로 403 에러 해결

### DIFF
--- a/src/main/java/com/unit_wiseb/value_calculator/domain/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/unit_wiseb/value_calculator/domain/common/filter/JwtAuthenticationFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -15,7 +16,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * HTTP 요청의 Authorization 헤더에서 JWT 토큰을 추출하고 검증
@@ -40,40 +41,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
 
         try {
-            //Authorization 헤더에서 JWT 토큰 추출
+            // Authorization 헤더에서 JWT 토큰 추출
             String token = extractTokenFromRequest(request);
+
+            log.info("=== JWT 필터 실행 ===");
+            log.info("요청 URI: {}", request.getRequestURI());
+            log.info("토큰 존재 여부: {}", token != null);
 
             // 토큰이 있고 유효한 경우
             if (token != null && jwtService.validateToken(token)) {
-                //토큰에서 사용자 ID 추출해서
+                // 토큰에서 사용자 ID 추출
                 Long userId = jwtService.getUserIdFromToken(token);
+                log.info("토큰 검증 성공 - userId: {}", userId);
 
-                // spring Security 인증 객체 생성함
+                // Spring Security 인증 객체 생성
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(
                                 userId,  // principal (사용자 ID)
                                 null,    // credentials (비밀번호 - JWT는 불필요)
-                                new ArrayList<>()  // authorities (권한 목록)
+                                Collections.singletonList(
+                                        new SimpleGrantedAuthority("ROLE_USER")
+                                )  // authorities (권한 목록)
                         );
 
-                //요청 정보 추가
+                // 요청 정보 추가
                 authentication.setDetails(
                         new WebAuthenticationDetailsSource().buildDetails(request)
                 );
 
-                //SecurityContext에 인증 정보 저장
+                // SecurityContext에 인증 정보 저장
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
-                log.debug("JWT 인증 성공: userId={}", userId);
+                log.info("SecurityContext에 인증 정보 저장 완료 - userId: {}", userId);
+
+            } else {
+                log.warn("토큰 검증 실패 또는 토큰 없음");
             }
 
         } catch (Exception e) {
-            log.error("JWT 인증 처리 중 오류 발생: {}", e.getMessage());
+            log.error("JWT 인증 처리 중 오류 발생: ", e);
             // 인증 실패 시 SecurityContext를 비워둠 (인증되지 않은 상태)
             SecurityContextHolder.clearContext();
         }
 
-        //다음 필터로 진행
+        // 다음 필터로 진행
         filterChain.doFilter(request, response);
     }
 
@@ -102,7 +113,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.equals("/swagger-ui.html")
                 || path.startsWith("/api/auth/");
     }
-
-
-
 }


### PR DESCRIPTION
1. 요청: POST /api/calculate + JWT 토큰
   ↓
2. JwtAuthenticationFilter 실행
   - 토큰 검증 ✅
   - userId 추출 ✅
   - SecurityContext에 저장 ✅
   - 하지만 authorities = [] (빈 배열)
   ↓
3. Spring Security 권한 체크
   - "인증됨?" → ✅ YES
   - "권한 있음?" → ❌ NO (빈 배열)
   ↓
4. 결과: 403 Forbidden 🚫